### PR TITLE
Add script and instructions for running locally using Docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 _site
+.bundler
 .sass-cache
 .jekyll-cache
 .jekyll-metadata

--- a/contributing.md
+++ b/contributing.md
@@ -45,6 +45,11 @@ You can report mistakes or errors, create more contents, etc. Whatever is your b
 1. `bundle install` will install this repository's dependencies
 1. `bundle exec jekyll serve --livereload` will run the website and dynamically reload it upon changes.
 
+# Running the website using Docker
+
+1. [Install Docker](https://docs.docker.com/engine/install/) if you have not already done so.
+1. Run the `./serve.sh` script in the top level of the repository. This will download the Ruby 3.2 Docker image and use it to serve the website on `https://localhost:4000`.
+
 # Post Metadata
 
 Each post should have a metadata block at the top of the file. This is used to generate the post's page and should look like:

--- a/serve.sh
+++ b/serve.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+if [ ! -d .bundler ] ; then
+    mkdir .bundler
+fi
+
+docker run -i -t --rm -u $(id -u):$(id -g) \
+    -p 4000:4000 -v $(pwd):/opt/app \
+    -v $(pwd)/.bundler/:/opt/bundler \
+    -e BUNDLE_PATH=/opt/bundler \
+    -w /opt/app ruby:3.2 \
+    bash -c "bundle install && bundle exec jekyll serve --livereload -H 0.0.0.0"


### PR DESCRIPTION
This adds a script that will run the blog site locally using Docker and adds some instructions to the contributing guide.