### PR TITLE
Add more metadata to post header

### DIFF
--- a/_includes/contributor-badge-inline.html
+++ b/_includes/contributor-badge-inline.html
@@ -1,8 +1,10 @@
 {%- assign contributor_badge_entity = site.data.CONTRIBUTORS[include.id] -%}
 {%- assign name = contributor_badge_entity.short_name | default: contributor_badge_entity.name | default: include.id -%}
-<a href="https://github.com/{{ include.id }}" class="contributor-badge-inline contributor-{{ include.id }}"  itemprop="author" itemscope itemtype="http://schema.org/Person">
+<a href="https://github.com/{{ include.id }}" class="{% unless include.clean %}contributor-badge-inline {% endunless %}"  itemprop="author" itemscope itemtype="http://schema.org/Person">
+  {%- unless include.clean %}
   {%- if contributor_badge_entity.orcid -%}<img src="{% link assets/images/orcid.png %}" alt="orcid logo" width="36" height="36"/>{%- endif -%}
   <img src="https://github.com/{{ include.id }}.png?size=36" alt="{{ name }}'s avatar" class="avatar" width="36" height="36" itemprop="image"/>
+  {% endunless %}
   <span class="p-author h-card" itemprop="name">
   {{ name }}
   </span>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -2,6 +2,7 @@
 <html lang="{{ page.lang | default: site.lang | default: "en" }}">
 
   {%- include head.html -%}
+   <link href="https://fonts.googleapis.com/css2?family=Recursive:slnt,wght,CASL,CRSV,MONO@-15..0,300..800,0..1,0..1,0..1&display=swap" rel="stylesheet">
 
   {% if page.external %}
   <link rel="canonical" href="{{ page.external }}">

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -3,19 +3,19 @@ layout: default
 ---
 <article class="post">
 
-  <header class="post-header">
-    <h1 class="post-title">{{ page.title | escape }}</h1>
-  </header>
+  <h1 class="post-title">{{ page.title | escape }}</h1>
 
   <div class="post-content">
     {{ content }}
   </div>
 
+  <div id="endmatter">
   {% if page.cited %}
   <div class="citations">
 	<h2 id="references">References</h2>
 	{% bibliography --cited %}
   </div>
   {% endif %}
+  </div>
 
 </article>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -5,29 +5,37 @@ layout: default
 	<h1 class="post-title p-name" itemprop="name headline">{{ page.title | escape }}</h1>
 	<header class="post-header">
 		<div class="post-meta">
-			<div style="display: flex; justify-content: space-between">
+			<div class="meta-title">Published</div>
 			<time class="dt-published" datetime="{{ page.published | date_to_xmlschema }}" itemprop="datePublished">
-			Published: {{ page.published | date: "%Y %b %d %H:%M" }}
+			{{ page.published | date: "%Y %b %d %H:%M" }}
 			</time>
 			{% if page.modified != page.published %}
+			<div class="meta-title">Updated</div>
 			<time class="dt-published" datetime="{{ page.modified | date_to_xmlschema }}" itemprop="dateUpdated">
-			Updated: {{ page.modified | date: "%Y %b %d %H:%M" }}
+			{{ page.modified | date: "%Y %b %d %H:%M" }}
 			</time>
 			{% endif %}
+
+			<div class="meta-title">Revision</div>
 			<span>
-			Revision {{ page.revision }}
+			{{ page.revision }}
 			</span>
 
-			<div id="post-tags">
+			<div class="meta-title">Reviewers</div>
+			<ul style="list-style: none; margin-left: 0; margin-bottom: 0">
+				{% for reviewer in page.reviewers %}
+				<li>{% include contributor-badge-inline.html id=reviewer clean=true %}</li>
+				{% endfor %}
+			</ul>
+
+			<div id="post-tags" class="meta-title">
+				Tagged
+			</div>
 			{% if page.tags %}
-			<span class="text-muted">Tagged:</span>
 			{% for tag in page.tags %}
 			<a href="{{ site.baseurl }}/tag/{{ tag | slugify }}" class="tag">{{ tag }}</a>
-			{%- if forloop.last == false %}, {% endif %}
 			{% endfor %}
 			{% endif %}
-			</div>
-			</div>
 		</div>
 	</header>
 	

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -2,9 +2,8 @@
 layout: default
 ---
 <article class="post h-entry" itemscope itemtype="http://schema.org/BlogPosting">
-
+	<h1 class="post-title p-name" itemprop="name headline">{{ page.title | escape }}</h1>
 	<header class="post-header">
-		<h1 class="post-title p-name" itemprop="name headline">{{ page.title | escape }}</h1>
 		<div class="post-meta">
 			<div style="display: flex; justify-content: space-between">
 			<time class="dt-published" datetime="{{ page.published | date_to_xmlschema }}" itemprop="datePublished">
@@ -29,13 +28,18 @@ layout: default
 			{% endif %}
 			</div>
 			</div>
-			{% if page.contributors %}
-			<span id="post-contributions">
-			{% include contributors-list.html contributors=page.contributors badge=true %}
-			</span >
-			{% endif %}
 		</div>
 	</header>
+	
+	<!-- authors -->
+	<div class="post-author">
+		{% if page.contributors %}
+		<span class="text-muted">By:</span>
+		<span id="post-contributions">
+		{% include contributors-list.html contributors=page.contributors badge=true %}
+		</span >
+		{% endif %}
+	</div>
 
   <div class="post-content e-content" itemprop="articleBody">
     {{ content }}
@@ -46,6 +50,7 @@ layout: default
     {% endif %}
   </div>
 
+  <div id="endmatter">
   {% if page.cited %}
   <div class="citations">
 	<h2 id="references">References</h2>
@@ -89,6 +94,7 @@ layout: default
         async>
     </script>
   </div>
+  </div>
 </article>
 
 
@@ -96,5 +102,4 @@ layout: default
 // update the date on load, or leave fallback of 'today'
 const citationTodaysDate = new Date();
 document.getElementById("citation-code").innerHTML = document.getElementById("citation-code").innerHTML.replace("TODAY", citationTodaysDate.toDateString());
-document.getElementById("citation-text").innerHTML = document.getElementById("citation-text").innerHTML.replace("TODAY", citationTodaysDate.toDateString());
 </script>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -8,11 +8,11 @@ layout: default
 		<div class="post-meta">
 			<div style="display: flex; justify-content: space-between">
 			<time class="dt-published" datetime="{{ page.published | date_to_xmlschema }}" itemprop="datePublished">
-			Published: {{ page.published | date: "%b %-d, %Y" }}
+			Published: {{ page.published | date: "%Y %b %d %H:%M" }}
 			</time>
 			{% if page.modified != page.published %}
 			<time class="dt-published" datetime="{{ page.modified | date_to_xmlschema }}" itemprop="dateUpdated">
-			Updated: {{ page.modified }}
+			Updated: {{ page.modified | date: "%Y %b %d %H:%M" }}
 			</time>
 			{% endif %}
 			<span>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -7,10 +7,18 @@ layout: default
 		<h1 class="post-title p-name" itemprop="name headline">{{ page.title | escape }}</h1>
 		<div class="post-meta">
 			<div style="display: flex; justify-content: space-between">
-			<time class="dt-published" datetime="{{ page.date | date_to_xmlschema }}" itemprop="datePublished">
-			{%- assign date_format = site.minima.date_format | default: "%b %-d, %Y" -%}
-			{{ page.date | date: date_format }}
+			<time class="dt-published" datetime="{{ page.published | date_to_xmlschema }}" itemprop="datePublished">
+			Published: {{ page.published | date: "%b %-d, %Y" }}
 			</time>
+			{% if page.modified != page.published %}
+			<time class="dt-published" datetime="{{ page.modified | date_to_xmlschema }}" itemprop="dateUpdated">
+			Updated: {{ page.modified }}
+			</time>
+			{% endif %}
+			<span>
+			Revision {{ page.revision }}
+			</span>
+
 			<div id="post-tags">
 			{% if page.tags %}
 			<span class="text-muted">Tagged:</span>

--- a/_plugins/mod.rb
+++ b/_plugins/mod.rb
@@ -1,0 +1,175 @@
+# frozen_string_literal: true
+require 'jekyll'
+PARENT_CWD = File.expand_path('..', __dir__) + '/'
+
+module Gtn
+  # Module for obtaining modification times of files.
+  # It walks the git history to record the last time a file was modified.
+  # This is faster than talking to the file system.
+  module ModificationTimes
+    @@TIME_CACHE = nil
+    @@COMMIT_COUNT_CACHE = nil
+
+    def self.init_cache
+      return unless @@TIME_CACHE.nil?
+
+      @@TIME_CACHE = {}
+      @@COMMIT_COUNT_CACHE = Hash.new(0)
+      Jekyll.logger.info '[Time/Mod] Filling Time Cache'
+      command
+        .split('XXYYZZ:')
+        .map { |x| x.split("\n\n") }
+        .select { |x| x.length > 1 }
+        .each do |date, files|
+        files.split(/\n/).each do |f|
+          @@TIME_CACHE[f] = Time.at(date.to_i) if !@@TIME_CACHE.key? f
+          @@COMMIT_COUNT_CACHE[f] += 1
+        end
+      end
+    end
+
+    def self.command
+      `git log --name-only --pretty='XXYYZZ:%ct'`
+    end
+
+    def self.time_cache
+      @@TIME_CACHE
+    end
+
+    def self.commit_count_cache
+      @@COMMIT_COUNT_CACHE
+    end
+
+    def self.clean_path(f)
+      if f =~ %r{^\./}
+        f[2..]
+      else
+        f
+      end
+    end
+
+    def self.obtain_modification_count(f_unk)
+      f = clean_path(f_unk)
+      init_cache
+      if @@COMMIT_COUNT_CACHE.key? f
+        @@COMMIT_COUNT_CACHE[f]
+      else
+        0
+      end
+    end
+
+    def self.obtain_time(f_unk)
+      f = clean_path(f_unk)
+      init_cache
+      if @@TIME_CACHE.key? f
+        @@TIME_CACHE[f]
+      else
+        begin
+          # Non git file.
+          @@TIME_CACHE[f] = File.mtime(f)
+          # Jekyll.logger.warn "[Time/Mod] No git cached time available for #{f}, defaulting to checkout"
+          @@TIME_CACHE[f]
+        rescue StandardError
+          Time.at(0)
+        end
+      end
+    end
+  end
+
+  # Module for obtaining original publication times of files.
+  # It walks the git history to record the last time a file was modified.
+  # This is faster than talking to the file system.
+  module PublicationTimes
+    @@TIME_CACHE = nil
+
+    def self.chase_rename(renames, path)
+      if renames.key? path
+        chase_rename(renames, renames[path])
+      else
+        path
+      end
+    end
+
+    def self.init_cache
+      return unless @@TIME_CACHE.nil?
+
+      @@TIME_CACHE = {}
+      renames = {}
+
+      Jekyll.logger.info '[Time/Pub] Filling Publication Time Cache'
+      command
+        .split('XXYYZZ:')
+        .map { |x| x.split("\n\n") }
+        .select { |x| x.length > 1 }
+        .each do |date, files|
+        files.split("\n").grep(/\.(md|html)$/).each do |f|
+          modification_type, path = f.split("\t")
+          if modification_type == 'A'
+            # Chase the renames.
+            final_filename = chase_rename(renames, path)
+            @@TIME_CACHE[final_filename] = Time.at(date.to_i)
+          elsif modification_type[0] == 'R'
+            _, moved_from, moved_to = f.split("\t")
+            renames[moved_from] = moved_to # Point from the 'older' version to the newer.
+          end
+        end
+      end
+      # pp renames
+    end
+
+    def self.command
+      `git log --first-parent --name-status --diff-filter=AR --pretty='XXYYZZ:%ct' `
+    end
+
+    def self.time_cache
+      @@TIME_CACHE
+    end
+
+    def self.clean_path(f)
+      if f =~ %r{^\./}
+        f[2..]
+      else
+        f
+      end
+    end
+
+    def self.obtain_time(f_unk)
+      f = clean_path(f_unk)
+      init_cache
+      if @@TIME_CACHE.key? f
+        @@TIME_CACHE[f]
+      else
+        begin
+          # Non git file.
+          @@TIME_CACHE[f] = File.mtime(f)
+          # Jekyll.logger.warn "[Time/Pub] No git cached time available for #{f}, defaulting to checkout"
+          @@TIME_CACHE[f]
+        rescue StandardError
+          Time.at(0)
+        end
+      end
+    end
+  end
+end
+
+Jekyll::Hooks.register :site, :pre_render do |site|
+  site.posts.docs.each do |post|
+    # remove PARENT_CWD from path, if present.
+    path = post.path.gsub(PARENT_CWD, '')
+    post.data['modified'] = Gtn::ModificationTimes.obtain_time(path)
+    post.data['revision'] = Gtn::ModificationTimes.obtain_modification_count(path)
+    post.data['published'] = Gtn::PublicationTimes.obtain_time(path)
+  end
+end
+
+if $PROGRAM_NAME == __FILE__
+  Gtn::ModificationTimes.init_cache
+  # pp Gtn::ModificationTimes.commit_count_cache
+  pp Gtn::ModificationTimes.time_cache
+
+  # Gtn::PublicationTimes.init_cache
+  # Gtn::PublicationTimes.time_cache.select do |_, v|
+  #   # Things in last 6 months
+  #   v > Time.now - (6 * 30 * 24 * 60 * 60)
+  # end.map { |k, v| puts "#{v} #{k}" }
+end

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -4,12 +4,11 @@
 @import "minima";
 @import "./rouge";
 
+.wrapper {
+	max-width: calc(1100px - 30px * 2);
+}
 code, .highlighter-rouge .highlight {
 	background: #fdf6e3; color: #657b83;
-}
-
-header {
-	border-bottom: 1px solid grey;
 }
 
 ul.text-list, ol.text-list {
@@ -98,4 +97,39 @@ a.external::after {
 
 details {
 	margin-bottom:1em;
+}
+
+article {
+	display: grid;
+	grid-template-rows: 3fr;
+	gap: 1em 1em;
+	grid-template-columns: repeat(6, 1fr);
+	grid-template-areas:
+	     ".   Title      Title      Title       Title       Title"
+	     ".   Author     Author     Author      Author      Meta"
+	     ".   Main       Main       Main        Main        Meta"
+	     ".   Endmatter  Endmatter  Endmatter   Endmatter   .";
+
+	@media (max-width: 768px) {
+		grid-template-columns: minmax(0, 1fr);
+		grid-template-areas:
+		  "Title"
+		  "Author"
+		  "Main"
+		  "Meta"
+		  "Endmatter";
+	}
+
+	.post-title { grid-area: Title; }
+	.post-header { grid-area: Meta; }
+	.post-content { grid-area: Main; }
+	.post-author { grid-area: Author; }
+	#endmatter  { grid-area: Endmatter; }
+
+	.post-author { display: flex; flex-direction: row; align-items: center; }
+	#post-contributions {
+		ul.text-list {
+			margin-bottom: 0;
+		}
+	}
 }

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -4,6 +4,25 @@
 @import "minima";
 @import "./rouge";
 
+* {
+	font-family: "Recursive", sans-serif;
+	font-weight: 370;
+}
+h1 {
+	font-variation-settings: "CASL" 0.200, "CRSV" 0;
+	font-weight: 500;
+}
+h2 {
+	font-variation-settings: "CASL" 0.400, "CRSV" 0.2;
+	font-weight: 450;
+}
+h3 {
+	font-variation-settings: "CASL" 0.600, "CRSV" 0.4;
+	font-weight: 400;
+}
+pre, code, kbd {
+	font-variation-settings: "MONO" 1, "CASL" 1, "CRSV" 0;
+}
 .wrapper {
 	max-width: calc(1100px - 30px * 2);
 }

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -125,6 +125,17 @@ article {
 	.post-content { grid-area: Main; }
 	.post-author { grid-area: Author; }
 	#endmatter  { grid-area: Endmatter; }
+	.post-meta {
+		display: flex;
+		flex-direction: column;
+
+		div.meta-title:not(:first-child) {
+			margin-top: 0.5em;
+		}
+		div.meta-title{
+			font-size: 1.2em;
+		}
+	}
 
 	.post-author { display: flex; flex-direction: row; align-items: center; }
 	#post-contributions {


### PR DESCRIPTION
![Screenshot 2024-06-06 at 13-31-04 What does it take to switch over to BAM from FASTQ](https://github.com/ubinfie/ubinfie.github.io/assets/458683/8babdbcb-d109-47c6-a480-737b2a02268c)

- post metadata moved to the right column
- this metadata appears at the end of the article on small width screens
- add a new font to give our site a bit of character