### PR TITLE
Fix image markdown

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -33,6 +33,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        fetch-depth: 0
       - name: Setup Ruby
         uses: ruby/setup-ruby@8575951200e472d5f2d95c625da0c7bec8217c42 # v1.161.0
         with:

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -42,7 +42,6 @@ layout: default
 	<!-- authors -->
 	<div class="post-author">
 		{% if page.contributors %}
-		<span class="text-muted">By:</span>
 		<span id="post-contributions">
 		{% include contributors-list.html contributors=page.contributors badge=true %}
 		</span >

--- a/_posts/2024-06-06-switch-to-bam.md
+++ b/_posts/2024-06-06-switch-to-bam.md
@@ -18,7 +18,7 @@ reviewers:
 
 uBAM is a strictly better storage format for your sequencing data, and you should switch to it today.
 
-{% link assets/images/switch-to-bam_gather-round.png %}
+![claymation style people sit on the grass around a large computer with ai generated text displayed. UBAM is visible in the text.]({% link assets/images/switch-to-bam_gather-round.png %})
 
 ## Background
 
@@ -194,7 +194,7 @@ and [Lyve-SET](https://github.com/lskatz/lyve-SET/), they do not natively read u
 I wish I could say that I will address this right away, but with all my other responsibilities, it will be further down the road.
 Therefore we can say from our own observations and personal experience, there is some work up ahead to get us moved over to uBAM files!
 
-{% link assets/images/switch-to-bam_scroll-of-truth.jpg %}
+![scroll of truth meme, the adventurer has finally found it after 15 years, the scroll of truth, uBAM is written on the scroll. he throws it away in disgust. Nyehh!]({% link assets/images/switch-to-bam_scroll-of-truth.jpg %})
 
 ### Footnotes
 


### PR DESCRIPTION
- I was careless, I should've checked it more carefully. Image markup added with proper alt.
- removed 'by' since it's implicit and renders poorly on mobile
- fixed metadata on deploy (requires full git clone)