### PR TITLE
Fix markdown in pixi post

### DIFF
--- a/_posts/2024-10-03-pixi-basics.md
+++ b/_posts/2024-10-03-pixi-basics.md
@@ -189,10 +189,11 @@ For Conda, I used [miniforge](https://github.com/conda-forge/miniforge) v24.7.1-
 Essentially, for conda it runs `conda create` followed by `rm -rf` to delete the environment. For pixi, it runs `pixi add`, `pixi install`, and then `pixi remove`.
 Then, it compares the average times.
 
-<details>
+<details markdown=1>
   <summary>
     Here is the actual script.
   </summary>
+
 
 ```bash
 #!/bin/bash
@@ -222,7 +223,7 @@ done
 
 </details>
 
-<details>
+<details markdown=1>
 
   <summary>
     Pixi created an environment faster than conda. Click for details.

--- a/_posts/2024-10-03-pixi-basics.md
+++ b/_posts/2024-10-03-pixi-basics.md
@@ -380,36 +380,36 @@ Here are some noteworthy caveats.
 
 * Python itself should be added to the dependencies section, e.g.,
 
-```toml
-[dependencies]
-python = ">=3.9"
-```
+  ```toml
+  [dependencies]
+  python = ">=3.9"
+  ```
 
 * pip requirements can be added under the `[project]` section, e.g.,
 
-```toml
-[project]
-dependencies = [
-    "numpy",
-    "pandas",
-    "matplotlib",
-]
-```
+  ```toml
+  [project]
+  dependencies = [
+      "numpy",
+      "pandas",
+      "matplotlib",
+  ]
+  ```
 
 * Specifically for Python, you can specify the required version with `requires-python` like so:
 
-```toml
-[project]
-requires-python = ">=3.9"
-```
+  ```toml
+  [project]
+  requires-python = ">=3.9"
+  ```
 
 * Adding pypi packages on the command line is straightforward too, e.g.,
 
-```bash
-# allows you to add a library to your python script, e.g., 
-#   from rich import print
-pixi add --pypi rich
-```
+  ```bash
+  # allows you to add a library to your python script, e.g., 
+  #   from rich import print
+  pixi add --pypi rich
+  ```
 
 ## Conclusions
 


### PR DESCRIPTION
`markdown=1` will tell Jekyll's markdown processor "Yes I actually manually wrote a real HTML element but please do process children as markdown again" 

additionally indented the code blocks at the bottom to ensure that the parent remains a single list with four bullets, rather than four lists with one bullet each.