### PR TITLE
Update 2024-04-02-shared-conda-tutorial.md - fix CONDA_PATH

### DIFF
--- a/_posts/2024-04-02-shared-conda-tutorial.md
+++ b/_posts/2024-04-02-shared-conda-tutorial.md
@@ -97,7 +97,7 @@ function conda {
         unset -f conda
 
         # shellcheck disable=SC1090
-        eval "$($CONDA_DIR/bin/conda shell.$SHELL_NAME hook)"
+        eval "$($CONDA_PATH/bin/conda shell.$SHELL_NAME hook)"
         conda "${@}"
 }
 ```


### PR DESCRIPTION
Line 100 makes reference to `CONDA_DIR` but it should be `CONDA_PATH`